### PR TITLE
fix: NativeDatabase is not a constructor

### DIFF
--- a/src/ExpoSQLiteNext.ts
+++ b/src/ExpoSQLiteNext.ts
@@ -22,13 +22,13 @@ export const mockedExpoSqliteNext = {
     for (const db of dbs) await db.closeAsync()
   },
 
-  NativeDatabase: (
+  NativeDatabase: function(
     databaseName: string,
     options?: SQLiteOpenOptions,
     serializedData?: Uint8Array
-  ) => new NativeDatabase(databaseName, options, serializedData),
+  ) { return new NativeDatabase(databaseName, options, serializedData) },
 
-  NativeStatement: () => new NativeStatement(),
+  NativeStatement: function() { return new NativeStatement()},
 
   defaultDatabaseDirectory: '.',
 


### PR DESCRIPTION
Fixes: #108 

Expo SDK 56 requires NativeDatabase to be a constructor. Therefor an arrow function cannot be used. This PR converts the two related functions.

Fix appears to be backward compatible with Expo Go SDK 55.